### PR TITLE
support pytest 6.x, fix python 3.6 support

### DIFF
--- a/pytest_dbt_adapter/spec_file.py
+++ b/pytest_dbt_adapter/spec_file.py
@@ -5,7 +5,7 @@ import shlex
 import tempfile
 from datetime import datetime
 from itertools import chain, repeat
-from subprocess import run, CalledProcessError
+from subprocess import run, CalledProcessError, PIPE
 from typing import Dict, Any, Iterable
 
 import pytest
@@ -235,7 +235,7 @@ class DbtItem(pytest.Item):
         if cli_vars:
             full_cmd.extend(('--vars', yaml.safe_dump(cli_vars)))
         expect_passes = sequence_item.get('check', True)
-        result = run(full_cmd, check=False, capture_output=True)
+        result = run(full_cmd, check=False, stdout=PIPE, stderr=PIPE)
         print(result.stdout.decode('utf-8'))
         if expect_passes:
             if result.returncode != 0:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ def read(path):
 setup(
     name='pytest-dbt-adapter',
     packages=['pytest_dbt_adapter'],
-    version='0.1.0',
+    author="Fishtown Analytics",
+    author_email="info@fishtownanalytics.com",
+    url="https://github.com/fishtown-analytics/dbt-adapter-tests",
+    version='0.2.0',
     package_data={
         'pytest_dbt_adapter': [
             'projects/*.yml',
@@ -21,7 +24,9 @@ setup(
             'pytest_dbt_adapter = pytest_dbt_adapter',
         ]
     },
-    install_requires=['py>=1.3.0', 'pyyaml'],
+    install_requires=['py>=1.3.0', 'pytest>=6,<7', 'pyyaml>3,<4'],
+    description="A pytest plugin for testing dbt adapter plugins",
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
+    python_requires=">=3.6.2",
 )


### PR DESCRIPTION
While setting up the presto test suite, I found out that I wrote this in a way that doesn't support python 3.6.

I also found out that I missed pytest 6.x being released, and figured it makes sense to update to requiring that, instead of going from 4.x -> 5.x