### PR TITLE
Rename seed for dbt-spark integration tests

### DIFF
--- a/pytest_dbt_adapter/projects/incremental.yml
+++ b/pytest_dbt_adapter/projects/incremental.yml
@@ -1,29 +1,29 @@
 name: incremental
 paths:
-    data/base.csv: files.seeds.base
-    data/extended.csv: files.seeds.added
-    models/incremental.sql: files.models.incremental
-    models/schema.yml: files.schemas.base
+  data/base.csv: files.seeds.base
+  data/added.csv: files.seeds.added
+  models/incremental.sql: files.models.incremental
+  models/schema.yml: files.schemas.base
 facts:
-    seed:
-        length: 2
-        names:
-            - base
-            - extended
-    run:
-        length: 1
-        names:
-            - incremental
-    catalog:
-        nodes:
-            length: 3
-        sources:
-            length: 1
-    persisted_relations:
-        - base
-        - extended
-        - incremental
-    base:
-        rowcount: 10
-    extended:
-        rowcount: 20
+  seed:
+    length: 2
+    names:
+      - base
+      - added
+  run:
+    length: 1
+    names:
+      - incremental
+  catalog:
+    nodes:
+      length: 3
+    sources:
+      length: 1
+  persisted_relations:
+    - base
+    - added
+    - incremental
+  base:
+    rowcount: 10
+  added:
+    rowcount: 20

--- a/pytest_dbt_adapter/sequences/incremental.yml
+++ b/pytest_dbt_adapter/sequences/incremental.yml
@@ -21,15 +21,15 @@ sequence:
   - type: dbt
     cmd: run
     vars:
-      seed_name: extended
+      seed_name: added
   - type: relation_rows
-    name: extended
-    length: fact.extended.rowcount
+    name: added
+    length: fact.added.rowcount
   - type: run_results
     length: fact.run.length
   - type: relations_equal
     relations:
-      - extended
+      - added
       - incremental
   - type: dbt
     cmd: docs generate

--- a/specs/spark-databricks.dbtspec
+++ b/specs/spark-databricks.dbtspec
@@ -17,7 +17,7 @@ projects:
     facts:
       base:
         rowcount: 10
-      extended:
+      added:
         rowcount: 20
   - overrides: snapshot_strategy_check_cols
     dbt_project_yml: &file_format_delta

--- a/specs/spark.dbtspec
+++ b/specs/spark.dbtspec
@@ -16,7 +16,7 @@ projects:
     facts:
       base:
         rowcount: 10
-      extended:
+      added:
         rowcount: 20
 sequences:
   test_dbt_empty: empty


### PR DESCRIPTION
Fixes bug for spark adapter tests that uses ODBC driver. `extended` is a keyword prohibited by ODBC driver, which causes tests that seed table named `extended` to fail 💥 crazy stuff. Also, updated dbtspec examples. This is currently blocking ODBC driver support in dbt-spark (https://github.com/fishtown-analytics/dbt-spark/pull/116)