### PR TITLE
Infer the node name from the unique_id

### DIFF
--- a/pytest_dbt_adapter/sequences/data_test.yml
+++ b/pytest_dbt_adapter/sequences/data_test.yml
@@ -8,5 +8,5 @@ sequence:
       length: fact.test.length
       names: fact.test.names
       attributes:
-        passing.fail: false
-        failing.fail: true
+        passing.status: pass
+        failing.status: fail

--- a/pytest_dbt_adapter/sequences/data_test_ephemeral_models.yml
+++ b/pytest_dbt_adapter/sequences/data_test_ephemeral_models.yml
@@ -12,8 +12,8 @@ sequence:
       length: fact.test.length
       names: fact.test.names
       attributes:
-        passing.fail: false
-        failing.fail: true
+        passing.status: pass
+        failing.status: fail
     - type: dbt
       cmd: run
     - type: run_results

--- a/pytest_dbt_adapter/spec_file.py
+++ b/pytest_dbt_adapter/spec_file.py
@@ -271,6 +271,17 @@ class DbtItem(pytest.Item):
             attributes[name][keypath] = value
         return attributes
 
+    @staticmethod
+    def _get_name(
+        unique_id: str
+    ) -> str:
+        """ turn a unique_id into just a node name. """
+        # The last part of the unique_id is the name
+        # Example:
+        #   Consider unique_id "test.dbt_test_project.failing"
+        #   Then the name is "failing"
+        return unique_id.split(".")[-1]
+
     def step_run_results(self, sequence_item, tmpdir):
         path = os.path.join(tmpdir, 'project', 'target', 'run_results.json')
 
@@ -302,7 +313,8 @@ class DbtItem(pytest.Item):
 
             for result in results:
                 try:
-                    name = result['node']['name']
+                    unique_id = result['unique_id']
+                    name = self._get_name(unique_id)
                 except KeyError as exc:
                     raise DBTException(
                         f'Invalid result, missing required key {exc}'
@@ -323,8 +335,8 @@ class DbtItem(pytest.Item):
 
             for result in results:
                 try:
-                    node = result['node']
-                    name = node['name']
+                    unique_id = result['unique_id']
+                    name = self._get_name(unique_id)
                 except KeyError as exc:
                     raise DBTException(
                         f'Invalid result, missing required key {exc}'


### PR DESCRIPTION
resolves #9 

## Description
Infer the node name from the unique_id (to support changes introduced in dbt 0.19.0).

The maintainers will need to determine how the version of this package will need to be bumped if this PR is accepted.

I'm guessing [this](https://github.com/fishtown-analytics/dbt/blob/a0eade4fdd091cd06a0d8e143db2d1a7456d3774/CHANGELOG.md#dbt-0190rc1-december-29-2020) entry from the CHANGELOG is where the breaking changes came from:  
- Rationalize run result status reporting and clean up artifact schema ([#2493](https://github.com/fishtown-analytics/dbt/issues/2493), [#2943](https://github.com/fishtown-analytics/dbt/pull/2943))

## Pros
- minimal set of changes to achieve passing tests

## Cons
- someone might have a more comprehensive vision for altering how `names` and `attributes` might work in 0.19.0+

## Caveats
- I didn't test this pull request against any dbt versions other than 0.19.0rc1 (or databases other than Postgres)
- depending on compatibility with versions earlier than 0.19.0rc1, either the dbt-adapter-tests version will need to be bumped or a different strategy will need to be taken

## Checklist
- [X] I have signed the CLA
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR